### PR TITLE
Add subscriptions multi user bug

### DIFF
--- a/CheckMeInDB/CheckMeIn_InitTables_SP.sql
+++ b/CheckMeInDB/CheckMeIn_InitTables_SP.sql
@@ -17,7 +17,7 @@ BEGIN
 	  CREATE TABLE OfferedSubscriptions
 	  (
 	  	SubscriptionID UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID() NOT NULL,
-	  	SubscriptionName NVARCHAR(128) NOT NULL
+	  	SubscriptionName NVARCHAR(128) NOT NULL UNIQUE
 	  )
 	  
 	  -- Create the ActiveSubscriptions tables

--- a/CheckMeInDB/CheckMeIn_InitTables_SP.sql
+++ b/CheckMeInDB/CheckMeIn_InitTables_SP.sql
@@ -27,7 +27,7 @@ BEGIN
 	  	SubscriberID UNIQUEIDENTIFIER FOREIGN KEY REFERENCES Subscribers(SubscriberID) NOT NULL,
 	  	SubscriptionID UNIQUEIDENTIFIER FOREIGN KEY REFERENCES OfferedSubscriptions(SubscriptionID) NOT NULL,
 	  	SubscriptionStartDate DATETIME NOT NULL,
-	  	PhoneNumber NVARCHAR(128) NOT NULL UNIQUE,
+	  	PhoneNumber NVARCHAR(128),
 	  )
 
 	  -- Create the CheckIn table

--- a/CheckMeInDB/Dockerfile
+++ b/CheckMeInDB/Dockerfile
@@ -1,0 +1,11 @@
+# Fetch latest image 
+FROM mcr.microsoft.com/azure-sql-edge:latest
+
+# Set environment variables
+ENV ACCEPT_EULA=1
+ENV MSSQL_SA_PASSWORD=StrongPassword!123
+# Using default
+ENV MSSQL_PID=Developer
+
+# Expose the SQL Server port
+EXPOSE 1433

--- a/CheckMeInDB/Dockerfile
+++ b/CheckMeInDB/Dockerfile
@@ -1,9 +1,10 @@
 # Fetch latest image 
-FROM mcr.microsoft.com/azure-sql-edge:latest
+FROM mcr.microsoft.com/azure-sql-edge
 
 # Set environment variables
 ENV ACCEPT_EULA=1
 ENV MSSQL_SA_PASSWORD=StrongPassword!123
+
 # Using default
 ENV MSSQL_PID=Developer
 

--- a/CheckMeInService/Controllers/CheckInAPI.cs
+++ b/CheckMeInService/Controllers/CheckInAPI.cs
@@ -12,10 +12,10 @@ public static class CheckInApi
 
         // Un-Enroll Active Subscription 
         group.MapDelete("/Unenroll",
-            (SubscriptionQueries subscriptionQueries, CheckInQueries checkInQueries, string phoneNumber) =>
+            (SubscriptionQueries subscriptionQueries, CheckInQueries checkInQueries, string phoneNumber, string subscriptionName) =>
             {
                 // First identify the active subscription 
-                var activeSubscriptions = subscriptionQueries.GetActiveSubscriptions(phoneNumber);
+                var activeSubscriptions = subscriptionQueries.GetActiveSubscriptions(phoneNumber, subscriptionName);
 
                 if (activeSubscriptions is null)
                     return Results.BadRequest($"Subscription not found for user with phone number: {phoneNumber}");
@@ -32,13 +32,13 @@ public static class CheckInApi
             });
 
         group.MapPut("/LogDaily",
-            (SubscriptionQueries subscriptionQueries, CheckInQueries checkInQueries, string phoneNumber) =>
+            (SubscriptionQueries subscriptionQueries, CheckInQueries checkInQueries, string phoneNumber, string subscriptionName) =>
             {
                 // First identify the active subscription 
-                var activeSubscriptions = subscriptionQueries.GetActiveSubscriptions(phoneNumber);
+                var activeSubscriptions = subscriptionQueries.GetActiveSubscriptions(phoneNumber, subscriptionName);
 
                 if (activeSubscriptions is null)
-                    return Results.BadRequest($"Subscription not found for user with phone number: {phoneNumber}");
+                    return Results.BadRequest($"Subscription not found for: {phoneNumber}");
 
                 // Create Check-in and make an entry in the history table
                 var result = checkInQueries.LogCheckIn(activeSubscriptions);
@@ -47,6 +47,7 @@ public static class CheckInApi
                 var checkIn = checkInQueries.GetCheckIn(activeSubscriptions.ActiveSubscriptionId);
                 var offeredSubscription =
                     subscriptionQueries.GetOfferedSubscription(activeSubscriptions.SubscriptionId);
+                
                 checkInQueries.CreateCheckInHistoryEntry(activeSubscriptions, checkIn, offeredSubscription);
 
                 if (checkIn == new CheckIn())

--- a/CheckMeInService/Controllers/SubscribersAPI.cs
+++ b/CheckMeInService/Controllers/SubscribersAPI.cs
@@ -9,13 +9,12 @@ public static class SubscribersApi
     {
         group.MapGet("/Test",
             () => Results.Ok("API is working"));
-        // todo: refactor
+        
         group.MapPost("/AddSubscription",
             (SubscriptionQueries subscriptionQueries, CheckInQueries checkInQueries, string firstName, string lastName,
                 string phoneNumber,
                 string subscriptionName) =>
             {
-                // Add the subscriber first if it does not exist
                 var newSubscriber = new Subscriber
                 {
                     FirstName = firstName, LastName = lastName, PhoneNumber = phoneNumber
@@ -33,7 +32,7 @@ public static class SubscribersApi
 
                     var res = subscriptionQueries.AddNewMemberSubscription(newSubscriber, offeredSubscription);
 
-                    var userSubscription = subscriptionQueries.GetActiveSubscriptions(phoneNumber);
+                    var userSubscription = subscriptionQueries.GetActiveSubscriptions(phoneNumber, subscriptionName);
 
                     if (userSubscription is null) return Results.BadRequest("No active user subscription found.");
 
@@ -53,7 +52,7 @@ public static class SubscribersApi
                 var newMemberResponse =
                     subscriptionQueries.AddNewMemberSubscription(existingSubscriber, offeredSubscription);
 
-                var activeSubscription = subscriptionQueries.GetActiveSubscriptions(phoneNumber);
+                var activeSubscription = subscriptionQueries.GetActiveSubscriptions(phoneNumber, subscriptionName);
 
                 if (activeSubscription is null) return Results.BadRequest("Active subscription not found");
 

--- a/CheckMeInService/Data/CheckInQueries.cs
+++ b/CheckMeInService/Data/CheckInQueries.cs
@@ -15,7 +15,7 @@ public class CheckInQueries : Connection
         using var checkInContext = new CheckMeInContext(ConnectionString);
 
         var newCheckInHistory = new CheckInHistory(activeSubscriptions.SubscriptionId, activeSubscriptions.SubscriberId,
-            checkIn.LastCheckInDate, subscriptionName);
+            checkIn.LastCheckInDate, subscriptionName.ToLower());
 
         checkInContext.CheckInHistory.Add(newCheckInHistory);
         checkInContext.SaveChanges();

--- a/CheckMeInService/Data/SubscriptionQueries.cs
+++ b/CheckMeInService/Data/SubscriptionQueries.cs
@@ -26,10 +26,21 @@ public class SubscriptionQueries : Connection
             .SingleOrDefault(x => x.SubscriptionName.ToLower() == subscriptionName.ToLower());
     }
 
-    public ActiveSubscriptions? GetActiveSubscriptions(string phoneNumber)
+    public ActiveSubscriptions? GetActiveSubscriptions(string phoneNumber, string subscriptionName )
     {
+        // Need to get the active subscription for the user that was asked of 
         using var checkMeInContext = new CheckMeInContext(ConnectionString);
-        return checkMeInContext.ActiveSubscriptions.SingleOrDefault(x => x.PhoneNumber == phoneNumber);
+        
+        // fetch the offered subscriptions
+        var currentSubscription =
+            checkMeInContext.OfferedSubscriptions.SingleOrDefault(x =>  x.SubscriptionName == subscriptionName);
+
+        if (currentSubscription is null)
+        {
+            return null;
+        }
+        
+        return checkMeInContext.ActiveSubscriptions.SingleOrDefault(x => x.PhoneNumber == phoneNumber && x.SubscriptionId == currentSubscription.SubscriptionId);
     }
 
     public bool VerifySubscriberExists(Subscriber subscriber)

--- a/CheckMeInService/Models/DatabaseSettings.cs
+++ b/CheckMeInService/Models/DatabaseSettings.cs
@@ -30,13 +30,17 @@ public class DatabaseSettings
             DataSource = DataSource,
             UserID = UserId,
             Password = Password,
-            InitialCatalog = InitialCatalog
+            InitialCatalog = InitialCatalog,
+// Only trust server cert in debug mode 
+#if DEBUG
+            TrustServerCertificate = true
+#endif
         };
 
         return builder.ConnectionString;
     }
 
-    public bool TestConnection()
+    public bool TestDatabaseConnection()
     {
         using var connection = new SqlConnection(GetConnection());
         try

--- a/CheckMeInService/Program.cs
+++ b/CheckMeInService/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 var app = builder.Build();
 
-if (settings.TestConnection() is false) throw new Exception("Unable to connect to the database");
+if (settings.TestDatabaseConnection() is false) throw new Exception("Unable to connect to the database");
 
 app.UseAuthorization();
 

--- a/CheckMeInServices_Tests/SubscriptionQueries_Tests.cs
+++ b/CheckMeInServices_Tests/SubscriptionQueries_Tests.cs
@@ -331,7 +331,7 @@ public class SubscriptionQueriesTests : IAsyncLifetime
     public void GetActiveSubscription_ValidPhoneNumber_ReturnsActiveSubscription()
     {
         // Arrange - Act
-        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("555-555-1111", "Exercise");
+        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("555-555-1111", "TestContainers");
 
         // Assert
         Assert.NotNull(activeSubscriptions);

--- a/CheckMeInServices_Tests/SubscriptionQueries_Tests.cs
+++ b/CheckMeInServices_Tests/SubscriptionQueries_Tests.cs
@@ -20,7 +20,6 @@ public class SubscriptionQueriesTests : IAsyncLifetime
             .Build();
     }
 
-
     // Setup DB container
     [Fact]
     public async Task InitializeAsync()
@@ -332,7 +331,7 @@ public class SubscriptionQueriesTests : IAsyncLifetime
     public void GetActiveSubscription_ValidPhoneNumber_ReturnsActiveSubscription()
     {
         // Arrange - Act
-        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("555-555-1111");
+        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("555-555-1111", "Exercise");
 
         // Assert
         Assert.NotNull(activeSubscriptions);
@@ -343,7 +342,7 @@ public class SubscriptionQueriesTests : IAsyncLifetime
     public void GetActiveSubscription_InvalidPhoneNumber_ReturnsNull()
     {
         // Arrange - Act
-        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("NotAPhoneNumber");
+        var activeSubscriptions = _subscriptionQueries.GetActiveSubscriptions("NotAPhoneNumber", "Not a subscription");
 
         // Assert
         Assert.Null(activeSubscriptions);


### PR DESCRIPTION
## Issue: when a user creates a new active subscription for a more than 1 existing subscription it'll throw an unhandled exception.

- Created a Dockerfile for future PR to introduce a local db for development. 
- Modified schemas to not allow multiple offered subscriptions with the same name. 
- Changes to CheckIn and Subscriptions controllers. 
- Changes to DB queries. 
- Updated tests to support the changes. 